### PR TITLE
解决libclang兼容性问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ``` bash
 # For Debian/Ubuntu
-sudo apt-get install xsel exuberant-ctags ack-grep
+sudo apt-get install xsel exuberant-ctags ack-grep 
 ```
 
 ## Installation
@@ -26,6 +26,7 @@ bash install.sh
 
 # optional (install YouCompleteMe)
 cd extra
+sudo apt-get install libclang-3.4-dev
 bash install.sh
 ```
 

--- a/extra/install.sh
+++ b/extra/install.sh
@@ -9,4 +9,4 @@ cd ~/.vim/bundle
 git clone --recursive https://github.com/Valloric/YouCompleteMe
 
 cd ~/.vim/bundle/YouCompleteMe
-./install.sh --clang-completer
+./install.sh --clang-completer --system-libclang


### PR DESCRIPTION
安装YCM时下载已经编译好的libclang库比较慢，而且容易出现兼容性问题。